### PR TITLE
Add basic CI pipeline

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+RSTEST_TIMEOUT = "300"
+RUST_TEST_THREADS = "1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+name: Tests and static analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: Check
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        kind: [debug, release]
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check ${{ matrix.kind == 'release' && '--release' || '' }}
+      - run: cargo clippy ${{ matrix.kind == 'release' && '--release' || '' }}
+
+  test:
+    name: Run tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        kind: [debug, release]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --no-fail-fast ${{ matrix.kind == 'release' && '--release' || '' }}
+
+  formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
+
+  build:
+    name: Build ${{ matrix.kind }} for ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        kind: [debug, release]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build ${{ matrix.kind == 'release' && '--release' || '' }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ matrix.kind == 'release' }}
+        with:
+          name: ${{ matrix.os == 'windows-latest' && 'aaoffline.exe' || 'aaoffline' }}
+          path: ${{ format('target/{0}/aaoffline{1}', matrix.kind, matrix.os == 'windows-latest' && '.exe' || '') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,10 @@
 name = "aaoffline"
 description = "Downloads cases from Ace Attorney Online to be playable offline"
 repository = "https://github.com/falko17/aaoffline"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
+authors = ["Falko Galperin <github@falko.de>"]
 
 [dependencies]
 anyhow = { version = "1.0.94", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,10 @@ strip = true
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 too_many_lines = "allow"
+
+[dev-dependencies]
+assert_cmd = "2.0.16"
+headless_chrome = "1.0.15"
+rstest = "0.23.0"
+rstest_reuse = "0.7.0"
+tempfile = "3.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.133"
 serde_with = { version = "3.11.0", features = ["chrono"] }
 tokio = { version = "1.42.0", features = ["full"] }
+tokio-stream = { version = "0.1.17", features = ["fs"] }
 urlencoding = "2.1.3"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Downloads cases from [Ace Attorney Online](https://aaonline.fr) to be playable offline.
 
-> [!WARNING]
-> This is in an early state and may not work correctly. Currently, I'm aware of the following problem:
->
-> 1. Psyche locks won't work correctly.
->
-> Additionally, the code is still a bit messy and largely undocumented.
+## Features
+
+- Backup cases in a way that makes them fully playable offline by downloading all referenced assets.
+- Use multiple parallel downloads to download case data quickly.
+- Download multiple cases at once.
+- Specify a specific version of the Ace Attorney Online (e.g., if a case only works with an older version).
 
 ## Usage
 
@@ -19,21 +19,21 @@ Cases can be downloaded by just putting the trial ID as an argument to `aaofflin
 aaoffline YOUR_ID_HERE
 ```
 
-Or, even simpler, you can pass the URL to the case directly:
+Or, even simpler, you can pass the URL[^1] to the case directly:
 
 ```bash
 aaoffline "http://www.aaonline.fr/player.php?trial_id=YOUR_ID_HERE"
 ```
 
-By default, the case will be put into a directory with the case ID as its name (you can change this by just passing a different directory name as another argument).
-The downloaded case can then be downloaded by opening the `index.html` file in the output directory.
+You can also pass more than one case at a time (separated by spaces) if you want to download multiple cases at once.
 
-There are some additional parameters you can set, such as `--concurrent-downloads` to choose a different number of parallel downloads to use[^1], or `--player-version` to choose a specific commit of the player (e.g., if a case only worked on an older version).
+By default, the case will be put into a directory with the case ID as its name. You can change this by just passing a different directory name as `-o some_directory`). If there are multiple cases, each case will be put into its own folder, again with its case ID as its name, all under the directory chosen with `-o` (or the current directory if none was set).
+The downloaded case can then be downloaded by opening the `index.html` file in the output directory—all case assets are put in the `assets` directory, so if you want to move this download somewhere else, you'll need to move the `assets` along with it.
+
+There are some additional parameters you can set, such as `--concurrent-downloads` to choose a different number of parallel downloads to use[^2], or `--player-version` to choose a specific commit of the player.
 To get an overview of available options, just run `aaoffline --help`.
 
-[^1]: This is set to 5 by default, but a higher number can lead to significantly faster downloads. Don't overdo it, though, or some servers may block you.
-
-## Building
+## Building / Installing
 
 Building `aaoffline` should be straightforward:
 
@@ -42,6 +42,13 @@ cargo build --release
 ```
 
 Afterwards, you can find the built `aaoffline` executable inside `target/release`.
+Alternatively, you can also install the tool to be globally available:
+
+```bash
+cargo install --path .
+```
+
+Then you can run `aaoffline` from anywhere.
 
 ## Troubleshooting
 
@@ -50,3 +57,7 @@ Afterwards, you can find the built `aaoffline` executable inside `target/release
 This is due to the HTML5 audio API being implemented differently in Firefox, refer to [#1](https://github.com/falko17/aaoffline/issues/1) for details.
 As a workaround, use the `--disable-html5-audio` option with `aaoffline`, and then use a local HTTP server to serve the files—this way does not use the HTML5 audio API.
 If you have Python installed, you can run `python3 -m http.server -d CASE_DIRECTORY` to run a simple web server, then you just need to access the URL it outputs.
+
+[^1]: Both modern `aaonline.fr` and out-of-date `aceattorney.sparklin.org` URLs are supported.
+
+[^2]: This is set to 5 by default, but a higher number can lead to significantly faster downloads. Don't overdo it, though, or some servers may block you.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,220 @@
+use std::{
+    error::Error,
+    fmt::Display,
+    sync::{Arc, Mutex, Weak},
+    time::Duration,
+};
+
+use assert_cmd::Command;
+use headless_chrome::{
+    browser::tab::EventListener,
+    protocol::cdp::{
+        types::Event,
+        Log::{
+            events::{EntryAddedEvent, EntryAddedEventParams},
+            LogEntry, LogEntryLevel,
+        },
+    },
+    Browser, LaunchOptionsBuilder,
+};
+use rstest::{fixture, rstest};
+use rstest_reuse::{apply, template};
+use tempfile::{tempdir, TempDir};
+
+const GAME_OF_TURNABOUTS: &str = "106140";
+// This one is also the smallest of these cases, so we will use it frequently.
+const PSYCHE_LOCK_TEST: &str = "89247";
+// To test if URLs work:
+const THE_TORRENTIAL_TURNABOUT: &str = "https://aaonline.fr/player.php?trial_id=99015";
+// To test if old URLs work:
+const TURNABOUT_OF_COURAGE: &str = "http://aceattorney.sparklin.org/jeu.php?id_proces=27826";
+
+const ALL_CASES: [&str; 4] = [
+    THE_TORRENTIAL_TURNABOUT,
+    PSYCHE_LOCK_TEST,
+    GAME_OF_TURNABOUTS,
+    TURNABOUT_OF_COURAGE,
+];
+
+/// A save that jumps immediately to the part where psyche locks appear.
+const PSYCHE_LOCK_SAVE: &str = "?save_data=eyJ0cmlhbF9pZCI6ODkyNDcsInNhdmVfZGF0ZSI6MTczNDM2OTM5OCwicGxheWVyX3N0YXR1cyI6eyJjdXJyZW50X2ZyYW1lX2lkIjoyNiwiY3VycmVudF9mcmFtZV9pbmRleCI6MjksIm5leHRfZnJhbWVfaW5kZXgiOjMwLCJsYXN0X2ZyYW1lX21lcmdlZCI6ZmFsc2UsImxhdGVzdF9hY3Rpb25fZnJhbWVfaW5kZXgiOjAsImNvbXB1dGVkX3BhcmFtZXRlcnMiOm51bGwsImdhbWVfZW52Ijp7IlRSVUUiOnRydWUsIkZBTFNFIjpmYWxzZX0sImhlYWx0aCI6MTIwLCJoZWFsdGhfZmxhc2giOjAsImdhbWVfb3Zlcl90YXJnZXQiOjAsInByb2NlZWRfY2xpY2siOnRydWUsInByb2NlZWRfY2xpY2tfbWV0IjpmYWxzZSwicHJvY2VlZF90aW1lciI6ZmFsc2UsInByb2NlZWRfdGltZXJfbWV0IjpmYWxzZSwicHJvY2VlZF90eXBpbmciOnRydWUsInByb2NlZWRfdHlwaW5nX21ldCI6dHJ1ZX0sInRvcF9zY3JlZW5fc3RhdGUiOnsicG9zaXRpb24iOnsiaWQiOi0xLCJuYW1lIjoiY2VudGVyIiwiYWxpZ24iOjAsInNoaWZ0IjowfSwicGxhY2UiOnsicGxhY2VfaWQiOi0xfSwiY2hhcmFjdGVycyI6eyJjdXJyZW50RGVmYXVsdFBvc2l0aW9uIjotMSwiY3VycmVudFBvc2l0aW9ucyI6eyItMSI6eyJpZCI6LTEsIm5hbWUiOiJjZW50ZXIiLCJhbGlnbiI6MCwic2hpZnQiOjB9LCItMiI6eyJpZCI6LTIsIm5hbWUiOiJsZWZ0X2FsaWduIiwiYWxpZ24iOi0xLCJzaGlmdCI6MH0sIi0zIjp7ImlkIjotMywibmFtZSI6InJpZ2h0X2FsaWduIiwiYWxpZ24iOjEsInNoaWZ0IjowfSwiLTQiOnsiaWQiOi00LCJuYW1lIjoiYWFpX3NpbmdsZV9sZWZ0IiwiYWxpZ24iOi0xLCJzaGlmdCI6LTg0fSwiLTUiOnsiaWQiOi01LCJuYW1lIjoiYWFpX3NpbmdsZV9yaWdodCIsImFsaWduIjoxLCJzaGlmdCI6ODR9LCItNiI6eyJpZCI6LTYsIm5hbWUiOiJhYWlfZG91YmxlX2xlZnRfbGVmdG1vc3QiLCJhbGlnbiI6LTEsInNoaWZ0IjotNjV9LCItNyI6eyJpZCI6LTcsIm5hbWUiOiJhYWlfZG91YmxlX2xlZnRfcmlnaHRtb3N0IiwiYWxpZ24iOi0xLCJzaGlmdCI6MzJ9LCItOCI6eyJpZCI6LTgsIm5hbWUiOiJhYWlfZG91YmxlX3JpZ2h0X2xlZnRtb3N0IiwiYWxpZ24iOjEsInNoaWZ0IjotMzJ9LCItOSI6eyJpZCI6LTksIm5hbWUiOiJhYWlfZG91YmxlX3JpZ2h0X3JpZ2h0bW9zdCIsImFsaWduIjoxLCJzaGlmdCI6NjV9LCItMTAiOnsiaWQiOi0xMCwibmFtZSI6ImFhaV9kb3VibGVfY2VudGVyX2xlZnRtb3N0IiwiYWxpZ24iOjAsInNoaWZ0IjotNjV9LCItMTEiOnsiaWQiOi0xMSwibmFtZSI6ImFhaV9kb3VibGVfY2VudGVyX3JpZ2h0bW9zdCIsImFsaWduIjowLCJzaGlmdCI6NjV9fSwiY2hhcmFjdGVycyI6eyIyIjp7Im1pcnJvcl9lZmZlY3QiOmZhbHNlLCJwb3NpdGlvbiI6LTEsInByb2ZpbGVfaWQiOjIsInNwcml0ZV9pZCI6LTYsInN0YXJ0dXBfbW9kZSI6MCwic3luY19tb2RlIjoxLCJ2aXN1YWxfZWZmZWN0X2FwcGVhcnMiOjAsInZpc3VhbF9lZmZlY3RfYXBwZWFyc19tb2RlIjowLCJ2aXN1YWxfZWZmZWN0X2Rpc2FwcGVhcnMiOjAsInZpc3VhbF9lZmZlY3RfZGlzYXBwZWFyc19tb2RlIjowfX0sImNoYXJhY3RlcnNfb3JkZXIiOlsyXX0sImxvY2tzIjp7ImN1cnJlbnRfbG9ja3NfZGlhbG9ndWVfZGVzYyI6eyJzY2VuZV9pZCI6IjEiLCJzY2VuZV90eXBlIjoic2NlbmVzIiwic2VjdGlvbl9pZCI6IjEiLCJzZWN0aW9uX3R5cGUiOiJkaWFsb2d1ZXMifSwiZGlzcGxheWVkX2xvY2tzIjpbeyJpZCI6MSwidHlwZSI6ImpmYV9sb2NrIiwieCI6MTI4LCJ5IjoxMjgsImJyb2tlbiI6ZmFsc2V9LHsiaWQiOjIsInR5cGUiOiJqZmFfbG9jayIsIngiOjIyNCwieSI6NjQsImJyb2tlbiI6ZmFsc2V9LHsiaWQiOjMsInR5cGUiOiJqZmFfbG9jayIsIngiOjMyLCJ5Ijo2NCwiYnJva2VuIjpmYWxzZX0seyJpZCI6NCwidHlwZSI6ImpmYV9sb2NrIiwieCI6MTc2LCJ5IjoxNjAsImJyb2tlbiI6ZmFsc2V9LHsiaWQiOjUsInR5cGUiOiJqZmFfbG9jayIsIngiOjgwLCJ5IjoxNjAsImJyb2tlbiI6ZmFsc2V9XX0sImNyX2ljb25zIjp7ImRpc3BsYXllZF9pY29ucyI6W119LCJwb3B1cHMiOnsicG9wdXBzIjpbXSwibGFzdF9mcmFtZV93YXNfbWVyZ2VkIjpmYWxzZX0sInRleHQiOnsibmFtZSI6IlBob2VuaXgiLCJ0ZXh0cyI6WyJbI3NiXVlvdSBhdGUgTXkgQnVyZ2VyLiJdLCJjb2xvcnMiOlsid2hpdGUiXSwicHJldmlvdXNfZnJhbWVfbWVyZ2VkIjpmYWxzZSwiY3VycmVudF9zcGVha2VyIjoxfSwiZmFkZSI6eyJmYWRlIjpudWxsfX0sImN1cnJlbnRfbXVzaWNfaWQiOjIsInRyaWFsX2RhdGFfZGlmZnMiOnsiODkyNDciOnsiZnJhbWVzIjp7Im9yaWdpbmFsUm93RWRpdHMiOnsiNCI6eyJoaWRkZW4iOmZhbHNlfX0sImJsb2NrRWRpdHMiOlt7InN0YXJ0X2luZGV4IjowLCJlbmRfaW5kZXgiOjg4LCJzaGlmdCI6MH1dLCJsZW5ndGgiOjg5fX19LCJ0cmlhbF9kYXRhX2Jhc2VfZGF0ZXMiOnsiODkyNDciOjE2MDE4ODU4ODd9fQ%3D%3D";
+
+struct Cmd {
+    cmd: Command,
+    path: TempDir,
+}
+
+impl Cmd {
+    fn path_as_str(&self) -> &str {
+        self.path.path().to_str().unwrap()
+    }
+}
+
+#[fixture]
+fn cmd() -> Cmd {
+    let mut cmd = Command::cargo_bin("aaoffline").unwrap();
+    cmd.args(["-s", "single"]);
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().to_str().unwrap();
+    cmd.args(["-o", path]);
+    Cmd { cmd, path: tmp }
+}
+
+#[template]
+#[rstest]
+fn example_cases(
+    #[values(
+        THE_TORRENTIAL_TURNABOUT,
+        PSYCHE_LOCK_TEST,
+        GAME_OF_TURNABOUTS,
+        TURNABOUT_OF_COURAGE
+    )]
+    case: &str,
+) {
+}
+
+#[derive(Debug)]
+struct JsError {
+    messages: Vec<String>,
+}
+
+impl Display for JsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JavaScript errors: {}", self.messages.join(","))
+    }
+}
+impl Error for JsError {}
+
+impl JsError {
+    fn check_messages(msgs: &[LogEntry]) -> Result<(), JsError> {
+        let messages: Vec<String> = msgs
+            .iter()
+            .filter(|x| x.level == LogEntryLevel::Error)
+            .map(|x| x.text.clone())
+            .collect();
+        if messages.is_empty() {
+            Ok(())
+        } else {
+            Err(JsError { messages })
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct JsListener {
+    messages: Arc<Mutex<Vec<LogEntry>>>,
+}
+
+impl EventListener<Event> for JsListener {
+    fn on_event(&self, event: &Event) {
+        if let Event::LogEntryAdded(EntryAddedEvent {
+            params: EntryAddedEventParams { entry },
+        }) = event
+        {
+            self.messages.lock().unwrap().push(entry.clone());
+        }
+    }
+}
+
+fn verify_with_browser(path: &str, query: Option<&str>) -> Result<(), Box<dyn Error>> {
+    let options = LaunchOptionsBuilder::default().build()?;
+    let browser = Browser::new(options)?;
+    let tab = browser.new_tab()?;
+    // We register a listener to capture any JavaScript errors, and then open the offline case.
+    tab.enable_log()?;
+    let listener: Arc<JsListener> = Arc::new(JsListener::default());
+    tab.add_event_listener(listener.clone())?;
+    tab.navigate_to(&format!(
+        "file://{path}/index.html{}",
+        query.unwrap_or_default()
+    ))?;
+    tab.wait_until_navigated()?;
+
+    // We click the "Start" button and wait a little while.
+    let start_button = tab.find_element("#start")?;
+    start_button.click()?;
+    let weak: Weak<dyn EventListener<Event> + Send + Sync> = Arc::downgrade(&listener) as Weak<_>;
+    tab.remove_event_listener(&weak)?;
+    let messages = listener.messages.lock().unwrap();
+    JsError::check_messages(&messages).map_err(Into::into)
+}
+
+#[rstest]
+fn test_invalid_id(
+    mut cmd: Cmd,
+    #[values(
+        "incorrect",
+        "",
+        "http://",
+        "https://",
+        "http://example.com/player.php?trial_id=1234",
+        "https://example.com/player.php?trial_id=1234",
+        "https://aaonline.fr/trial.php?trial_id=1234",
+        "http://aaonline.fr/player.php?trial_id=",
+        "https://aaonline.fr/player.php?trial_id=",
+        "12 34",
+        "-1234"
+    )]
+    case_id: &str,
+) {
+    cmd.cmd.arg(case_id).assert().failure();
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(60))]
+fn test_html5_cors_error(mut cmd: Cmd) {
+    cmd.cmd
+        .arg("--disable-html5-audio")
+        .arg(PSYCHE_LOCK_TEST)
+        .assert()
+        .success();
+    let errors = verify_with_browser(cmd.path_as_str(), None)
+        .expect_err("expected CORS errors when not using HTML5 audio");
+    if let Some(JsError { messages }) = errors.downcast_ref::<JsError>() {
+        assert!(messages
+            .iter()
+            .all(|x| x.contains("CORS") || x.contains("net::ERR_FAILED")));
+    } else {
+        panic!("expected JsError, got {errors:?}");
+    }
+}
+
+fn get_id(case: &str) -> &str {
+    case.trim_start_matches(|x: char| !x.is_numeric())
+}
+
+#[rstest]
+fn test_non_existing(mut cmd: Cmd, #[values("0", "999999", "9999999999999999")] case_id: &str) {
+    cmd.cmd.arg(case_id).assert().failure();
+}
+
+#[apply(example_cases)]
+fn test_single(mut cmd: Cmd, case: &str) {
+    cmd.cmd.arg(case).assert().success();
+    verify_with_browser(cmd.path_as_str(), None).unwrap();
+}
+
+// These are tricky to get right, so we'll add a special test for these.
+#[rstest]
+fn test_psyche_locks(mut cmd: Cmd) {
+    cmd.cmd.arg(PSYCHE_LOCK_TEST).assert().success();
+    verify_with_browser(cmd.path_as_str(), Some(PSYCHE_LOCK_SAVE)).unwrap();
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(60 * 10))]
+fn test_sequence() {
+    let mut cmd = Command::cargo_bin("aaoffline").unwrap();
+    cmd.args(["-s", "every"]);
+    cmd.args(["-o", tempdir().unwrap().path().to_str().unwrap()]);
+    cmd.arg(GAME_OF_TURNABOUTS).assert().success();
+}
+
+#[rstest]
+fn test_multi(mut cmd: Cmd) {
+    cmd.cmd.args(ALL_CASES).assert().success();
+    for case in ALL_CASES {
+        let case_id = get_id(case);
+        verify_with_browser(&format!("{}/{case_id}", cmd.path_as_str()), None).unwrap();
+    }
+}


### PR DESCRIPTION
The intention of this PR is mainly to test the newly added GitHub Actions CI.

Additional changes include:
- Refactored previously synchronous actions (e.g., writing to the filesystem) to use async Rust (specifically, `tokio`).
- Added integration tests to make sure the tool works correctly. This works by, after downloading the case, running a headless Chromium browser and making sure there are no JavaScript errors in the console.
- Updated README.md and increased version number to 1.0.0, as I now have everything in here that I wanted for a "stable" (well, stable enough) release.