### PR TITLE
Various changes for 1.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,14 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # We want to regularly run the tests, since the AAO player may often get updated.
+    - cron: "47 4 * * *"
 
 jobs:
   check:
     name: Check
+    if: ${{ github.event_name != 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -38,6 +42,7 @@ jobs:
 
   formatting:
     name: Check formatting
+    if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +51,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.kind }} for ${{ matrix.os }}
+    if: ${{ github.event_name != 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aaoffline"
 description = "Downloads cases from Ace Attorney Online to be playable offline"
 repository = "https://github.com/falko17/aaoffline"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 authors = ["Falko Galperin <github@falko.de>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ urlencoding = "2.1.3"
 [profile.release]
 codegen-units = 1
 lto = true
-strip = true
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -46,6 +45,7 @@ too_many_arguments = "allow"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
+glob = "0.3.1"
 headless_chrome = "1.0.15"
 rstest = "0.23.0"
 rstest_reuse = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ strip = true
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 too_many_lines = "allow"
+too_many_arguments = "allow"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ itertools = "0.13.0"
 log = "0.4.22"
 regex = "1.11.1"
 reqwest = { version = "0.12.9", features = ["gzip"] }
+sanitize-filename = "0.6.0"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.133"
 serde_with = { version = "3.11.0", features = ["chrono"] }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Downloads cases from [Ace Attorney Online](https://aaonline.fr) to be playable o
 - Backup cases in a way that makes them fully playable offline by downloading all referenced assets.
 - Use parallel downloads to download case data quickly.
 - Download multiple cases at once.
+- Use the `-1` flag to compile the case into a single HTML file, without the need for a separate assets folder.
 - Choose a specific version of the Ace Attorney Online player (e.g., if a case only works with an older version).
 
 ## Usage
@@ -27,8 +28,9 @@ aaoffline "http://www.aaonline.fr/player.php?trial_id=YOUR_ID_HERE"
 
 You can also pass more than one case at a time (separated by spaces) if you want to download multiple cases at once.
 
-By default, the case will be put into a directory with the case ID as its name. You can change this by just passing a different directory name as `-o some_directory`. If there are multiple cases, each case will be put into its own folder, again with the case ID as its name, all under the directory chosen with `-o` (or the current directory if none was set).
+By default, the case will be put into a directory with the case title as its name. You can change this by just passing a different directory name as `-o some_directory`. If there are multiple cases, each case will be put into its own folder, again with the case title as its name, all under the directory chosen with `-o` (or the current directory if none was set).
 The downloaded case can then be played by opening the `index.html` file in the output directory—all case assets are put in the `assets` directory, so if you want to move this downloaded case somewhere else, you'll need to move the `assets` along with it.
+Alternatively, you can pass the `-1` flag to aaoffline, which causes the case to be compiled into a single (large) HTML file, with the assets encoded as data URLs instead of being put into separate files. (Warning: Browsers may not like HTML files very much that are multiple dozens of megabytes large. Your mileage may vary.)
 
 There are some additional parameters you can set, such as `--concurrent-downloads` to choose a different number of parallel downloads to use[^2], or `--player-version` to choose a specific commit of the player.
 To get an overview of available options, just run `aaoffline --help`.

--- a/src/data/case.rs
+++ b/src/data/case.rs
@@ -54,7 +54,7 @@ pub(crate) struct CaseInformation {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Sequence {
     /// The title of the sequence.
-    title: String,
+    pub(crate) title: String,
     /// The list of entries in the sequence.
     list: Vec<SequenceEntry>,
 }
@@ -63,6 +63,11 @@ impl Sequence {
     /// Returns a list of case IDs in this sequence.
     pub(crate) fn entry_ids(&self) -> Vec<u32> {
         self.list.iter().map(|x| x.id).collect()
+    }
+
+    /// Returns the number of cases contained in this sequence.
+    pub(crate) fn len(&self) -> usize {
+        self.list.len()
     }
 }
 

--- a/src/data/case.rs
+++ b/src/data/case.rs
@@ -128,6 +128,11 @@ impl Case {
         self.case_information.id
     }
 
+    /// Returns what we shall use as a file or directory name for this case.
+    pub(crate) fn filename(&self) -> String {
+        format!("{}_{}", &self.case_information.title, self.id())
+    }
+
     /// Retrieves a case using the given [`case_id`] from Ace Attorney Online.
     pub(crate) async fn retrieve_from_id(case_id: u32, client: &Client) -> Result<Case> {
         let case_script = client.get(format!(

--- a/src/data/case.rs
+++ b/src/data/case.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use serde_with::formats::Flexible;
 use serde_with::TimestampSeconds;
 
+use std::collections::HashSet;
 use std::fmt::Display;
 
 use crate::constants::re;
@@ -160,14 +161,14 @@ impl Case {
         })
     }
 
-    /// Returns a list of character and sprite IDs for default sprites used in this case.
+    /// Returns a list of character and sprite IDs for sprites used in this case.
     pub(crate) fn get_used_sprites(&self) -> Vec<(i64, i64)> {
         trace!("{}", self.case_data);
         // We are filtering out numbers here because for some reason, the arrays always
         // contain a "0: 0" element.
         self.case_data
             .as_object()
-            .expect("Trial data must be object")["frames"]
+            .expect("Case data must be object")["frames"]
             .as_array()
             .expect("frames must be array")
             .iter()
@@ -192,6 +193,23 @@ impl Case {
                         sprite_id.as_i64().expect("sprite_id must be integer"),
                     ))
                 }
+            })
+            .collect()
+    }
+
+    /// Returns a set of place IDs for places used in this case.
+    pub(crate) fn get_used_places(&self) -> HashSet<i64> {
+        self.case_data
+            .as_object()
+            .expect("Case data must be object")["frames"]
+            .as_array()
+            .expect("frames must be array")
+            .iter()
+            .filter(|x| !x.is_number())
+            .map(|x| {
+                x.as_object().expect("frame must be object")["place"]
+                    .as_i64()
+                    .expect("place in frame must be natural number")
             })
             .collect()
     }

--- a/src/data/case.rs
+++ b/src/data/case.rs
@@ -135,7 +135,7 @@ impl Case {
 
     /// Returns what we shall use as a file or directory name for this case.
     pub(crate) fn filename(&self) -> String {
-        format!("{}_{}", &self.case_information.title, self.id())
+        sanitize_filename::sanitize(format!("{}_{}", &self.case_information.title, self.id()))
     }
 
     /// Retrieves a case using the given [`case_id`] from Ace Attorney Online.

--- a/src/data/site.rs
+++ b/src/data/site.rs
@@ -8,7 +8,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::constants::{re, AAONLINE_BASE, BRIDGE_URL};
 
@@ -20,8 +20,8 @@ use crate::constants::{re, AAONLINE_BASE, BRIDGE_URL};
 pub(crate) struct DefaultData {
     /// Names of default profiles that have a startup animation.
     pub(crate) default_profiles_startup: HashSet<String>,
-    /// Deserialized default places.
-    pub(crate) default_places: Value,
+    /// Map from (non-positive) place ID to the corresponding deserialized place.
+    pub(crate) default_places: HashMap<i64, Value>,
 }
 
 impl DefaultData {
@@ -37,7 +37,7 @@ impl DefaultData {
         };
 
         let default_places =
-            super::retrieve_escaped_json::<Value>(&re::DEFAULT_PLACES_REGEX, module)?;
+            super::retrieve_escaped_json::<HashMap<i64, Value>>(&re::DEFAULT_PLACES_REGEX, module)?;
         Ok(DefaultData {
             default_profiles_startup,
             default_places,

--- a/src/data/site.rs
+++ b/src/data/site.rs
@@ -16,12 +16,24 @@ use crate::constants::{re, AAONLINE_BASE, BRIDGE_URL};
 ///
 /// Note that this does not contain all default data, only the data that is relevant to the
 /// retrieval and offline transformation process.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct DefaultData {
     /// Names of default profiles that have a startup animation.
     pub(crate) default_profiles_startup: HashSet<String>,
     /// Map from (non-positive) place ID to the corresponding deserialized place.
     pub(crate) default_places: HashMap<i64, Value>,
+    /// Map from voice ID and extension to data URL.
+    ///
+    /// May be empty if we are not collecting data URLs.
+    pub(crate) default_voice_urls: HashMap<(u64, String), String>,
+    /// Map from character base, sprite ID, and kind to data URL.
+    ///
+    /// May be empty if we are not collecting data URLs.
+    pub(crate) default_sprite_urls: HashMap<(String, i64, String), String>,
+    /// Map from psyche lock filename to data URL.
+    ///
+    /// May be empty if we are not collecting data URLs.
+    pub(crate) psyche_lock_urls: HashMap<String, String>,
 }
 
 impl DefaultData {
@@ -41,6 +53,7 @@ impl DefaultData {
         Ok(DefaultData {
             default_profiles_startup,
             default_places,
+            ..Default::default()
         })
     }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use log::{debug, error, trace, warn};
 use regex::Regex;
 use reqwest::Client;
+use sanitize_filename::sanitize;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -186,12 +187,16 @@ impl AssetCollector {
         let name = urlencoding::decode(&name)
             .map(Cow::into_owned)
             .unwrap_or(name);
-        let first_choice = self.output.join("assets").join(&name).with_extension(&ext);
+        let first_choice = self
+            .output
+            .join("assets")
+            .join(sanitize(name.clone()))
+            .with_extension(&ext);
         // If we used this filename already, we need to append a hash.
         if self.path_exists(&first_choice) {
             self.output
                 .join("assets")
-                .join(format!("{name}-{}", Self::hash(url)))
+                .join(sanitize(format!("{name}-{}", Self::hash(url))))
                 .with_extension(ext)
         } else {
             first_choice

--- a/src/download.rs
+++ b/src/download.rs
@@ -261,6 +261,13 @@ impl AssetCollector {
             .replace_all(url, "$1/")
             .to_string();
         trace!("{url} to {}", path.display());
+        assert!(
+            path.parent()
+                .expect("parent dir must exist")
+                .ends_with("assets"),
+            "must end with assets/ but doesn't: {}",
+            path.display()
+        );
         // Reassign icon to contain new name.
         *file_value = Value::String(
             // We need to strip the output prefix here, as the URL that's written to the trial data
@@ -631,13 +638,15 @@ impl<'a> AssetDownloader<'a> {
             // Evidence can contain two types of assets:
             // 1.) Icons.
             let external = evidence["icon_external"].as_bool();
-            self.collector.collect_download(
-                &mut evidence["icon"],
-                Some(paths.evidence_path()),
-                external,
-                Some("png"),
-                JsonReference::for_case(case_id, format!("/evidence/{i}/icon")),
-            );
+            if evidence["icon"].as_str().is_some_and(|x| !x.is_empty()) {
+                self.collector.collect_download(
+                    &mut evidence["icon"],
+                    Some(paths.evidence_path()),
+                    external,
+                    Some("png"),
+                    JsonReference::for_case(case_id, format!("/evidence/{i}/icon")),
+                );
+            }
             evidence["icon_external"] = Value::Bool(true);
 
             // 2.) "Check button data", which may be an image or a sound.

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,10 +396,14 @@ impl MainContext {
     fn ask_sequence(&self, case: &Case, sequence: &Sequence) -> bool {
         if stdin().is_terminal() {
             let result = self.pb.suspend(|| {
-                println!(
+                info!(
                     "The case \"{}\" is part of a sequence: {sequence}.",
-                    case.case_information.title
+                    case.case_information.title,
                 );
+                if sequence.len() <= 1 {
+                    info!("However, as there is only entry in this sequence, we will continue normally.");
+                    return Some(false);
+                }
                 let result = dialoguer::Confirm::new()
                     .with_prompt("Do you want to download the other cases in this sequence too?")
                     .default(false)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,8 +30,11 @@ const PSYCHE_LOCK_TEST: &str = "89247";
 const THE_TORRENTIAL_TURNABOUT: &str = "https://aaonline.fr/player.php?trial_id=99015";
 // To test if old URLs work:
 const TURNABOUT_OF_COURAGE: &str = "http://aceattorney.sparklin.org/jeu.php?id_proces=27826";
+// This one has evidence without an icon, which caused issue #3:
+const BROKEN_COMMANDMENTS: &str = "140935";
 
-const ALL_CASES: [&str; 4] = [
+// Cases used in multi-download test:
+const MULTI_CASES: [&str; 4] = [
     THE_TORRENTIAL_TURNABOUT,
     PSYCHE_LOCK_TEST,
     GAME_OF_TURNABOUTS,
@@ -77,7 +80,8 @@ fn example_cases(
         THE_TORRENTIAL_TURNABOUT,
         PSYCHE_LOCK_TEST,
         GAME_OF_TURNABOUTS,
-        TURNABOUT_OF_COURAGE
+        TURNABOUT_OF_COURAGE,
+        BROKEN_COMMANDMENTS
     )]
     case: &str,
 ) {
@@ -239,10 +243,10 @@ fn test_sequence() {
 fn test_multi(mut cmd: Cmd) {
     cmd.with_tmp_output(false)
         .cmd
-        .args(ALL_CASES)
+        .args(MULTI_CASES)
         .assert()
         .success();
-    for case in ALL_CASES {
+    for case in MULTI_CASES {
         let case_id = get_id(case);
         let path = glob_one(&format!("{}/*_{case_id}/", cmd.path_as_str()));
         verify_with_browser(path.as_os_str().to_str().unwrap(), None).unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -189,14 +189,20 @@ fn test_non_existing(mut cmd: Cmd, #[values("0", "999999", "9999999999999999")] 
 }
 
 #[apply(example_cases)]
-fn test_single(mut cmd: Cmd, case: &str) {
+fn test_single(mut cmd: Cmd, case: &str, #[values(true, false)] one_file: bool) {
+    if one_file {
+        cmd.cmd.arg("-1");
+    }
     cmd.cmd.arg(case).assert().success();
     verify_with_browser(cmd.path_as_str(), None).unwrap();
 }
 
 // These are tricky to get right, so we'll add a special test for these.
 #[rstest]
-fn test_psyche_locks(mut cmd: Cmd) {
+fn test_psyche_locks(mut cmd: Cmd, #[values(true, false)] one_file: bool) {
+    if one_file {
+        cmd.cmd.arg("-1");
+    }
     cmd.cmd.arg(PSYCHE_LOCK_TEST).assert().success();
     verify_with_browser(cmd.path_as_str(), Some(PSYCHE_LOCK_SAVE)).unwrap();
 }


### PR DESCRIPTION
This contains some additional features and fixes—after this is merged, I'll release version 1.1.0.

## New features
This adds the following functionality:
* You can now use the `-1` (or `--one-html-file`) flag to compile the case into a single HTML file, without the need for the separate `assets` folder.[^1]
* The output filenames / directory names are now more descriptive. Instead of just the case ID, they now also contain the case title.
* Only the default places that are actually used are downloaded.

## Bugfixes
* Only download the default places that are actually used.
* Handle cases with icon-less evidence correctly. A test for this was also added.
	* Thank you to @time-axis for the bug reports!
* When a case is part of a sequence that contains only a single case (the one the user requested to download anyway), we won't ask whether to download the whole sequence.

## Additional changes
* The CI pipeline is now configured to run the tests daily, in case there are any sudden incompatible changes to AAO.
* A test was added to make sure the correct output paths are being used.

[^1]: This is done using base64 data URLs. Large cases may slow the browser down a bit, since the HTML files can get quite large due to all assets being encoded in them.