### PR TITLE
Handle case-insensitive file systems correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aaoffline"
 description = "Downloads cases from Ace Attorney Online to be playable offline"
 repository = "https://github.com/falko17/aaoffline"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Falko Galperin <github@falko.de>"]

--- a/src/download.rs
+++ b/src/download.rs
@@ -180,10 +180,19 @@ impl AssetCollector {
     }
 
     /// Checks whether a [path] exists already in the collected downloads.
-    fn path_exists(&self, path: &PathBuf) -> bool {
-        self.collected
-            .iter()
-            .any(|x| x.as_ref().ok().map_or(false, |x| x.path == *path))
+    fn path_exists(&self, path: &Path) -> bool {
+        // Need to use a lower-case comparison here, otherwise we'll run into problems on Windows
+        // (where the file system is usually case-insensitive).
+        let lower_path = path
+            .to_str()
+            .expect("Invalid path encountered")
+            .to_lowercase();
+        self.collected.iter().any(|x| {
+            x.as_ref()
+                .ok()
+                .and_then(|y| y.path.to_str())
+                .map_or(false, |y| y.to_lowercase() == lower_path)
+        })
     }
 
     /// Creates a new unique path for the given [url] and [path].


### PR DESCRIPTION
This PR fixes #5, which was caused by the `AssetCollector` acting case-sensitive when checking for existing paths, which causes problems on systems like Windows that have case-insensitive file systems.
To fix this, `path_exists` now converts the paths it checks to lowercase first (if it detects an asset with a filename that was already used, a hash is appended to ensure uniqueness).