### PR TITLE
Various fixes for v1.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aaoffline"
 description = "Downloads cases from Ace Attorney Online to be playable offline"
 repository = "https://github.com/falko17/aaoffline"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 authors = ["Falko Galperin <github@falko.de>"]

--- a/src/data/case.rs
+++ b/src/data/case.rs
@@ -25,7 +25,7 @@ use crate::data::RegexNotMatched;
 
 /// Represents the information of a case.
 #[serde_with::serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub(crate) struct CaseInformation {
     /// The name of the author of the case.
     author: String,
@@ -51,7 +51,7 @@ pub(crate) struct CaseInformation {
 }
 
 /// A sequence of connected cases.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Sequence {
     /// The title of the sequence.
     pub(crate) title: String,
@@ -87,7 +87,7 @@ impl Display for Sequence {
 }
 
 /// An entry (case) in a sequence.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SequenceEntry {
     /// The ID of the case.
     id: u32,
@@ -119,7 +119,7 @@ impl Display for CaseInformation {
 }
 
 /// A case for the Ace Attorney Online player.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub(crate) struct Case {
     /// Metadata about this case.
     pub(crate) case_information: CaseInformation,

--- a/src/download.rs
+++ b/src/download.rs
@@ -256,7 +256,7 @@ impl AssetCollector {
         ignore_inaccessible: bool,
         json_ref: JsonReference,
     ) -> Result<AssetDownload> {
-        let file_string = file_value.as_str().unwrap_or(&self.default_icon_url);
+        let file_string = file_value.as_str().unwrap_or(&self.default_icon_url).trim();
         if file_string.is_empty() {
             return Err(EmptyUrl.into());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -582,7 +582,7 @@ async fn main() -> Result<()> {
                 .any(|x| ctx.output.join(x.to_string()).exists())
         {
             error!(
-                "Output at {} already exists. Please remove it or use --overwrite-existing.",
+                "Output at {} already exists. Please remove it or use --remove-existing.",
                 ctx.output.display()
             );
             std::process::exit(exitcode::DATAERR);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -175,7 +175,7 @@ fn test_invalid_id(
 }
 
 #[rstest]
-#[timeout(Duration::from_secs(60))]
+#[timeout(Duration::from_secs(60 * 5))]
 fn test_html5_cors_error(mut cmd: Cmd) {
     cmd.with_tmp_output(false)
         .cmd


### PR DESCRIPTION
This fixes the following issues:
- #8
- #9
- Duplicate cases are now only counted and downloaded once (apart from specifying the same trial multiple times, this also fixes an issue where downloading a sequence included the initially specified case twice).