### PR TITLE
Small fixes for v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ indicatif = "0.17.9"
 infer = { version = "0.16.0", default-features = false }
 itertools = "0.14.0"
 log = "0.4.22"
+mime2ext = "0.1.53"
 regex = "1.11.1"
 reqwest = { version = "0.12.9", features = ["gzip"] }
 reqwest-middleware = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aaoffline"
 description = "Downloads cases from Ace Attorney Online to be playable offline"
 repository = "https://github.com/falko17/aaoffline"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT"
 authors = ["Falko Galperin <github@falko.de>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,33 +8,33 @@ license = "MIT"
 authors = ["Falko Galperin <github@falko.de>"]
 
 [dependencies]
-anyhow = { version = "1.0.94", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 base64 = "0.22.1"
 bytes = "1.9.0"
 chrono = "0.4.39"
-clap = { version = "4.5.23", features = ["derive"] }
-clap-verbosity-flag = "3.0.1"
+clap = { version = "4.5.27", features = ["derive"] }
+clap-verbosity-flag = "3.0.2"
 colored = "3.0.0"
 const_format = "0.2.34"
 dialoguer = "0.11.0"
-env_logger = "0.11.5"
+env_logger = "0.11.6"
 exitcode = "1.1.2"
 futures = "0.3.31"
 human-panic = "2.0.2"
-indicatif = "0.17.9"
+indicatif = "0.17.11"
 infer = { version = "0.16.0", default-features = false }
 itertools = "0.14.0"
-log = "0.4.22"
+log = "0.4.25"
 mime2ext = "0.1.53"
 regex = "1.11.1"
-reqwest = { version = "0.12.9", features = ["gzip"] }
+reqwest = { version = "0.12.12", features = ["gzip"] }
 reqwest-middleware = "0.4.0"
 reqwest-retry = "0.7.0"
 sanitize-filename = "0.6.0"
-serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.133"
-serde_with = { version = "3.11.0", features = ["chrono"] }
-tokio = { version = "1.42.0", features = ["full"] }
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+serde_with = { version = "3.12.0", features = ["chrono"] }
+tokio = { version = "1.43.0", features = ["full"] }
 tokio-stream = { version = "0.1.17", features = ["fs"] }
 urlencoding = "2.1.3"
 
@@ -49,9 +49,9 @@ too_many_arguments = "allow"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
-glob = "0.3.1"
+glob = "0.3.2"
 headless_chrome = "1.0.15"
 maplit = "1.0.2"
 rstest = "0.24.0"
 rstest_reuse = "0.7.0"
-tempfile = "3.14.0"
+tempfile = "3.16.0"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -99,6 +99,10 @@ pub(crate) mod re {
 
     pub(crate) static CONTENT_DISPOSITION_FILENAME_REGEX: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"filename="([^"]*?)""#).unwrap());
+
+    pub(crate) static GRAPHIC_ELEMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"\s+element\.style\.height\s*=\s*img\.height\s*\+\s*['"]px['"];"#).unwrap()
+    });
 }
 
 pub(crate) const AAONLINE_BASE: &str = "https://aaonline.fr";

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -41,6 +41,9 @@ const BROKEN_COMMANDMENTS: &str = "140935";
 const SEQUENCE_TEST: &str = "148564";
 /// This one uses assets whose file extensions change after redirects.
 const DRAGON: &str = "83543";
+/// This one uses some links with neither an extension nor the "right" default extension,
+/// causing #13.
+const DECEITFUL: &str = "147274";
 
 // Cases used in multi-download test:
 const MULTI_CASES: [&str; 4] = [
@@ -92,6 +95,7 @@ fn example_cases(
         TURNABOUT_OF_COURAGE,
         BROKEN_COMMANDMENTS,
         CASCADE_THEATER_ASCENSION,
+        DECEITFUL,
         DRAGON
     )]
     case: &str,


### PR DESCRIPTION
This includes some smaller fixes for the last release, namely:
- A fix (and test) for #13.
- We now use the MIME type to deduce a file extension if the URL contains none.
- A workaround was added for a problem in which sprites sometimes don't appear until they've finished talking.